### PR TITLE
Fix initial frame index

### DIFF
--- a/src/plugin/main.js
+++ b/src/plugin/main.js
@@ -280,6 +280,8 @@ class AnimatedTiles extends Phaser.Plugins.ScenePlugin {
                                 });
                             // time until jumping to next frame
                             animatedTileData.next = animatedTileData.frames[0].duration;
+                            // set correct currentFrame if animation starts with different tile than the one with animation flag
+                            animatedTileData.currentFrame = animatedTileData.frames.findIndex(f => f.tileid === index + tileset.firstgid);
                             // Go through all layers for tiles
                             map.layers.forEach(
                                 (layer) => {


### PR DESCRIPTION
Hi, thanks for the plugin, it's great. 

There is one scenario I have problem with. If you create animation in Tiled and change order of frames, so the tile which is marked as animated is not first, it doesn't work. This small fix should find the correct initial frame index.