### PR TITLE
Update package.json to work with npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "phaser-animated-tiles",
   "version": "2.0.2",
   "description": "Phaser 3 Animated Tiles Plugin",
-  "main": "src/main.js",
+  "main": "src/plugin/main.js",
   "scripts": {
     "build": "webpack --config webpack.build.config.js",
     "demo": "webpack --config webpack.demo.config.js",

--- a/package.json
+++ b/package.json
@@ -32,5 +32,8 @@
     "phaser": "3.8.0",
     "webpack": "^4.8.3",
     "webpack-cli": "^2.1.3"
+  },
+  "peerDependencies": {
+    "phaser": "^3.x"
   }
 }


### PR DESCRIPTION
(there is no src/main, but there is a src/plugin/main, and I think that's what you intended).
This should allow a straightforward `npm i phaser-animated-tiles --save` and then
```
import AnimatedTiles from 'phaser-animated-tiles'
...
```
If you accept this, please bump the minor rev and republish?

FYI I'm using this for https://browndragon.tumblr.com/post/623913399368187904/fidough-work-starting-now . Thanks!