### PR TITLE
bugfix - memory leak on scene switch

### DIFF
--- a/src/plugin/main.js
+++ b/src/plugin/main.js
@@ -239,7 +239,10 @@ class AnimatedTiles extends Phaser.Plugins.ScenePlugin {
     }
 
     //  Called when a Scene shuts down, it may then come back again later (which will invoke the 'start' event) but should be considered dormant.
-    shutdown() {}
+    shutdown() {
+        // dercetech@github: this fixes a memory leak; a ref to all tiles in a scene would be retained in spite of switching scenes.
+        this.animatedTiles.length = 0;
+    }
 
 
     //  Called when a Scene is destroyed by the Scene Manager. There is no coming back from a destroyed Scene, so clear up all resources here.


### PR DESCRIPTION
Hi @nkholski , just found this one retaining a ref to all the tiles in a scene. Quickly builds up a heap of dead links and still refreshes the animations of unrendered zombie sprites. This single liner fixes the issue.