### PR TITLE
The plugin now works when there are null tiles

### DIFF
--- a/src/plugin/main.js
+++ b/src/plugin/main.js
@@ -308,7 +308,7 @@ class AnimatedTiles extends Phaser.Plugins.ScenePlugin {
                                             tileRow.forEach(
                                                 (tile) => {
                                                     // Tiled start index for tiles with 1 but animation with 0. Thus that wierd "-1"                                                    
-                                                    if ((tile.index - tileset.firstgid) === index) {
+                                                    if (tile && (tile.index - tileset.firstgid) === index) {
                                                         tiles.push(tile);
                                                     }
                                                 }


### PR DESCRIPTION
When there are null tiles, the plugin will throw an error. This patch fixes that.